### PR TITLE
Added filter so only Movies are processed #74 #98

### DIFF
--- a/EmbyStat.Common/Constants.cs
+++ b/EmbyStat.Common/Constants.cs
@@ -63,6 +63,11 @@ namespace EmbyStat.Common
             public const string ApiKey = "BWLRSNRC0AQUIEYX";
         }
 
+        public static class Type
+        {
+            public const string Movie = "Movie";
+        }
+
         //CHARTS
         public const string CountPerGenre = "COMMON.COUNTPERGENRE";
         public const string CountPerCommunityRating = "COMMON.COUNTPERCOMMUNITYRATING";

--- a/EmbyStat.Tasks/Tasks/MediaSyncTask.cs
+++ b/EmbyStat.Tasks/Tasks/MediaSyncTask.cs
@@ -7,6 +7,7 @@ using EmbyStat.Api.EmbyClient;
 using EmbyStat.Api.EmbyClient.Model;
 using EmbyStat.Api.Tvdb;
 using EmbyStat.Api.Tvdb.Models;
+using EmbyStat.Common;
 using EmbyStat.Common.Converters;
 using EmbyStat.Common.Models;
 using EmbyStat.Common.Tasks;
@@ -144,7 +145,7 @@ namespace EmbyStat.Tasks.Tasks
             var embyMovies = await _embyClient.GetItemsAsync(query, cancellationToken);
 
             _progressLogger.LogInformation($"Ready to add movies to database. We found {embyMovies.TotalRecordCount} movies");
-            return embyMovies.Items.Select(MovieHelper.ConvertToMovie);
+            return embyMovies.Items.Where(x => x.Type == Constants.Type.Movie).Select(MovieHelper.ConvertToMovie);
         }
 
         #endregion


### PR DESCRIPTION
When boxset is enabled on Emby it will send Boxset types on the API even when only asked for Movie types.

Fix: We filter for only Movie type items before processing the items.